### PR TITLE
[QU-5473] - Change CDN from maxcdn to jsdelivr

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License
 
 Copyright (c) 2015 HeyUpdate Ltd. http://www.heyupdate.com
+Copyright (c) 2024 Jadu Ltd. https://www.jadu.net
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Built to work with [Twemoji images](http://twitter.github.io/twemoji/).
 use HeyUpdate\Emoji\Emoji;
 use HeyUpdate\Emoji\EmojiIndex;
 
-$emoji = new Emoji(new EmojiIndex(), '//cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/%s.png');
+$emoji = new Emoji(new EmojiIndex(), '//cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/%s.svg');
 $emoji->replaceEmojiWithImages('🎈 :balloon:');
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Built to work with [Twemoji images](http://twitter.github.io/twemoji/).
 use HeyUpdate\Emoji\Emoji;
 use HeyUpdate\Emoji\EmojiIndex;
 
-$emoji = new Emoji(new EmojiIndex(), '//twemoji.maxcdn.com/36x36/%s.png');
+$emoji = new Emoji(new EmojiIndex(), '//cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/%s.png');
 $emoji->replaceEmojiWithImages('🎈 :balloon:');
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Emoji images from unicode characters and names (i.e. `:sunrise:`).
 Built to work with [Twemoji images](http://twitter.github.io/twemoji/).
 
 ``` php
-use HeyUpdate\Emoji\Emoji;
-use HeyUpdate\Emoji\EmojiIndex;
+use Jadu\Emoji\Emoji;
+use Jadu\Emoji\EmojiIndex;
 
 $emoji = new Emoji(new EmojiIndex(), '//cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/%s.svg');
 $emoji->replaceEmojiWithImages('🎈 :balloon:');
@@ -16,7 +16,7 @@ $emoji->replaceEmojiWithImages('🎈 :balloon:');
 Via Composer
 
 ``` bash
-$ composer require heyupdate/emoji
+$ composer require jadu/emoji
 ```
 
 ## Requirements
@@ -40,4 +40,4 @@ $ phpunit
 
 ## License
 
-The MIT License (MIT). Please see [License File](https://github.com/heyupdate/Emoji/blob/master/LICENSE) for more information.
+The MIT License (MIT). Please see [License File](https://github.com/jadu/Emoji/blob/master/LICENSE) for more information.

--- a/bin/compile_index.php
+++ b/bin/compile_index.php
@@ -2,14 +2,14 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-use HeyUpdate\Emoji\UnicodeUtil;
+use Jadu\Emoji\UnicodeUtil;
 
 $configFile = __DIR__.'/../config/index.json';
 
 $template = <<<'TEMPLATE'
 <?php
 
-namespace HeyUpdate\Emoji\Index;
+namespace Jadu\Emoji\Index;
 
 class CompiledIndex extends BaseIndex
 {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "heyupdate/emoji",
+    "name": "jadu/emoji",
     "description": "Convert unicode and named (i.e. :smile:) Emoji into images",
     "keywords": ["emoji"],
     "type": "library",
@@ -12,7 +12,7 @@
     },
     "autoload": {
         "psr-4": {
-            "HeyUpdate\\Emoji\\": "src/"
+            "Jadu\\Emoji\\": "src/"
         }
     },
     "extra": {

--- a/src/Emoji.php
+++ b/src/Emoji.php
@@ -22,7 +22,7 @@ class Emoji
      */
     public function __construct(
         IndexInterface $index,
-        $imageHtmlTemplate = '<img alt=":{{name}}:" class="emoji" src="https://twemoji.maxcdn.com/36x36/{{unicode}}.png">'
+        $imageHtmlTemplate = '<img alt=":{{name}}:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/{{unicode}}.png">'
     ) {
         $this->setIndex($index);
         $this->setImageHtmlTemplate($imageHtmlTemplate);

--- a/src/Emoji.php
+++ b/src/Emoji.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace HeyUpdate\Emoji;
+namespace Jadu\Emoji;
 
-use HeyUpdate\Emoji\Index\IndexInterface;
+use Jadu\Emoji\Index\IndexInterface;
 
 class Emoji
 {

--- a/src/Emoji.php
+++ b/src/Emoji.php
@@ -22,7 +22,7 @@ class Emoji
      */
     public function __construct(
         IndexInterface $index,
-        $imageHtmlTemplate = '<img alt=":{{name}}:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/{{unicode}}.png">'
+        $imageHtmlTemplate = '<img alt=":{{name}}:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/{{unicode}}.svg">'
     ) {
         $this->setIndex($index);
         $this->setImageHtmlTemplate($imageHtmlTemplate);

--- a/src/Index/BaseIndex.php
+++ b/src/Index/BaseIndex.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HeyUpdate\Emoji\Index;
+namespace Jadu\Emoji\Index;
 
 class BaseIndex implements IndexInterface
 {

--- a/src/Index/CompiledIndex.php
+++ b/src/Index/CompiledIndex.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HeyUpdate\Emoji\Index;
+namespace Jadu\Emoji\Index;
 
 class CompiledIndex extends BaseIndex
 {

--- a/src/Index/IndexInterface.php
+++ b/src/Index/IndexInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HeyUpdate\Emoji\Index;
+namespace Jadu\Emoji\Index;
 
 interface IndexInterface
 {

--- a/src/UnicodeUtil.php
+++ b/src/UnicodeUtil.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HeyUpdate\Emoji;
+namespace Jadu\Emoji;
 
 class UnicodeUtil
 {

--- a/tests/EmojiTest.php
+++ b/tests/EmojiTest.php
@@ -16,13 +16,13 @@ class EmojiTest extends \PHPUnit_Framework_TestCase
     public function testEmojiReplacesUnicodeEmojiWithImage()
     {
         $replacedString = $this->emoji->replaceEmojiWithImages('I ❤ Emoji');
-        $this->assertSame('I <img alt=":heart:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/2764.png"> Emoji', $replacedString);
+        $this->assertSame('I <img alt=":heart:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/2764.svg"> Emoji', $replacedString);
     }
 
     public function testEmojiReplacesNamedEmojiWithImage()
     {
         $replacedString = $this->emoji->replaceEmojiWithImages('Merry Christmas :santa:');
-        $this->assertSame('Merry Christmas <img alt=":santa:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/1f385.png">', $replacedString);
+        $this->assertSame('Merry Christmas <img alt=":santa:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/1f385.svg">', $replacedString);
     }
 
     public function testReplaceNamedWithUnicode()

--- a/tests/EmojiTest.php
+++ b/tests/EmojiTest.php
@@ -16,13 +16,13 @@ class EmojiTest extends \PHPUnit_Framework_TestCase
     public function testEmojiReplacesUnicodeEmojiWithImage()
     {
         $replacedString = $this->emoji->replaceEmojiWithImages('I ❤ Emoji');
-        $this->assertSame('I <img alt=":heart:" class="emoji" src="https://twemoji.maxcdn.com/36x36/2764.png"> Emoji', $replacedString);
+        $this->assertSame('I <img alt=":heart:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/2764.png"> Emoji', $replacedString);
     }
 
     public function testEmojiReplacesNamedEmojiWithImage()
     {
         $replacedString = $this->emoji->replaceEmojiWithImages('Merry Christmas :santa:');
-        $this->assertSame('Merry Christmas <img alt=":santa:" class="emoji" src="https://twemoji.maxcdn.com/36x36/1f385.png">', $replacedString);
+        $this->assertSame('Merry Christmas <img alt=":santa:" class="emoji" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/1f385.png">', $replacedString);
     }
 
     public function testReplaceNamedWithUnicode()

--- a/tests/EmojiTest.php
+++ b/tests/EmojiTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace HeyUpdate\Emoji;
+namespace Jadu\Emoji;
 
-use HeyUpdate\Emoji\Index\CompiledIndex;
+use Jadu\Emoji\Index\CompiledIndex;
 
 class EmojiTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Index/IndexTest.php
+++ b/tests/Index/IndexTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace HeyUpdate\Emoji;
+namespace Jadu\Emoji;
 
-use HeyUpdate\Emoji\Index\CompiledIndex;
+use Jadu\Emoji\Index\CompiledIndex;
 
 class IndexTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
> The folks over at [MaxCDN](https://www.maxcdn.com/) have graciously provided CDN support.
> 
> MaxCDN is shut down right now, so in the meanwhile use a different CDN or download the assets. (See [Maxcdn has shut down, cdn not working anymore. · Issue #580 · twitter/twemoji](https://github.com/twitter/twemoji/issues/580)).

 – https://github.com/twitter/twemoji/blob/master/README.md


Reading into the reported bug: It is mentioned you can use a new package with a new (and configurable) CDN:
> 
> the new package is called @twemoji/api

– https://github.com/twitter/twemoji/issues/580 



Looking at what sources this new package uses:

> CDN Support
> 
> Default CDN support is provided via [jsDelivr](https://www.jsdelivr.com/).

– https://www.npmjs.com/package/@twemoji/api 



The new cdn doesn’t seem to support the 36x36 size, with defaults at 72x72. 

New: https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f603.png

Old: https://twemoji.maxcdn.com/32x32/1f603.png



But it does support the svg format, so I have opted to include that change here as vectors will reduce latency, reduce filesize and increase image clarity.



Final: https://cdn.jsdelivr.net/gh/jdecked/twemoji/assets/svg/1f603.svg


For more info on the new CDN: https://www.jsdelivr.com/package/gh/jdecked/twemoji



As this is the first PR after altering the original source I have also updated the licence (MIT) and namespace references
-